### PR TITLE
Fixed theme switcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ And define a color scheme in params section
   # colorScheme = "alexpate-96"
 ```
 
+If no color scheme is set, the page will display a theme switcher in its header.
+
 ## Theme Previews
 
 ### alexpate-15 

--- a/hacker/layouts/partials/header.html
+++ b/hacker/layouts/partials/header.html
@@ -1,1 +1,3 @@
-{{ partial "theme-switcher.html" . }}
+{{ if eq ($.Param "colorScheme") "default"}}
+  {{ partial "theme-switcher.html" . }}
+{{ end }}


### PR DESCRIPTION
Hello,

I wanted to use this theme for my own page but it seemed the theme switcher was not functioning properly, so I fixed it for you. Now, if the colorScheme Param is set to `default`, it will show the theme switcher. If any other Colorscheme is set, the switcher will be hidden. The Pull-Request also adds a mention to the README.md file, so that other people that want to use the package know that.

Also, is it okay if I make my own Remix out of the theme?

Thanks in advance :)